### PR TITLE
Fix 'mpv not found' when running `cargo build`

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -585,15 +585,15 @@ pkgs.mkShell {
     ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
       # Build library search paths for all buildInputs
       LIB_PATHS="${pkgs.lib.makeLibraryPath buildInputs}"
-      LINK_ARGS=""
+      LINK_ARGS=()
       # Split colon-separated paths and create individual -L flags for each
-      for lib in $(echo "$LIB_PATHS" | tr ':' ' '); do
-        LINK_ARGS="$LINK_ARGS -C link-arg=-L$lib"
+      for lib in ''${LIB_PATHS//:/ }; do
+        LINK_ARGS+=("-C link-arg=-L$lib")
       done
 
       # Set target-specific RUSTFLAGS which merge with config file rustflags
-      export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$LINK_ARGS"
-      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$LINK_ARGS"
+      export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="''${LINK_ARGS[*]}"
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="''${LINK_ARGS[*]}"
     ''}
 
     # Set up GStreamer plugin paths - include core gstreamer plugins


### PR DESCRIPTION
When running `cargo build` in `nix develop`, I got the following error:

```shell
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: mold: fatal: library not found: mpv
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
This was a prerequisite for fixing an issue on my side when running on Ubuntu 25.10.

Disclaimer: not a Rust developer